### PR TITLE
Remove unused React import

### DIFF
--- a/src/pages/RegulatoryCompliance.tsx
+++ b/src/pages/RegulatoryCompliance.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { Helmet } from 'react-helmet-async';
 // import { Link } from 'react-router-dom';
 import { Globe, Shield, CheckCircle, AlertTriangle, FileText, Users } from 'lucide-react';


### PR DESCRIPTION
Remove unused `React` import to resolve TS6133.

---
<a href="https://cursor.com/background-agent?bcId=bc-4fc178cb-3ca5-41a0-b95c-b8459f41a8f2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4fc178cb-3ca5-41a0-b95c-b8459f41a8f2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

