### PR TITLE
Fix jsx property on style element

### DIFF
--- a/src/pages/RegulatoryCompliance.tsx
+++ b/src/pages/RegulatoryCompliance.tsx
@@ -1086,7 +1086,7 @@ const RegulatoryCompliance = () => {
         </div>
 
         {/* Custom CSS for animations */}
-        <style jsx>{`
+        <style>{`
           @keyframes grid-move {
             0% { transform: translate(0, 0); }
             100% { transform: translate(60px, 60px); }


### PR DESCRIPTION
Replace `<style jsx>` with `<style>` to resolve a TypeScript type error.

---
<a href="https://cursor.com/background-agent?bcId=bc-04a684a2-9a4a-4fd9-90c5-77a5c390ee42">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-04a684a2-9a4a-4fd9-90c5-77a5c390ee42">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

