### PR TITLE
Fix typescript declaration error

### DIFF
--- a/src/pages/RegulatoryCompliance.tsx
+++ b/src/pages/RegulatoryCompliance.tsx
@@ -741,7 +741,9 @@ const RegulatoryCompliance = () => {
     }
   ];
 
-  const getStatusColor = (status) => {
+  type CountryStatus = 'regulated' | 'restricted' | 'banned';
+
+  const getStatusColor = (status: CountryStatus | string) => {
     switch (status) {
       case 'regulated': return 'border-green-500 bg-green-50';
       case 'restricted': return 'border-yellow-500 bg-yellow-50';
@@ -750,7 +752,7 @@ const RegulatoryCompliance = () => {
     }
   };
 
-  const getStatusIcon = (status) => {
+  const getStatusIcon = (status: CountryStatus | string) => {
     switch (status) {
       case 'regulated': return <CheckCircle className="h-5 w-5 text-green-600" />;
       case 'restricted': return <AlertTriangle className="h-5 w-5 text-yellow-600" />;


### PR DESCRIPTION
Add explicit types to `getStatusColor` and `getStatusIcon` parameters to resolve implicit `any` errors and address a reported TS1128 compilation issue.

The initial problem was a TS1128 'Declaration or statement expected' error. While the direct fix involved typing parameters to resolve implicit `any` errors, this also led to a successful build, suggesting the TS1128 might have been a symptom of a stale TypeScript server cache or an indirect consequence of the untyped parameters.

---
<a href="https://cursor.com/background-agent?bcId=bc-7d39f1f1-fa47-499c-a048-b58d52460f5f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7d39f1f1-fa47-499c-a048-b58d52460f5f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

