### PR TITLE
Fix regulatory compliance expression error

### DIFF
--- a/src/pages/RegulatoryCompliance.tsx
+++ b/src/pages/RegulatoryCompliance.tsx
@@ -741,7 +741,7 @@ const RegulatoryCompliance = () => {
     }
   ];
 
-  const getStatusColor = (status) => {
+  const getStatusColor = (status: 'regulated' | 'restricted' | 'banned' | string): string => {
     switch (status) {
       case 'regulated': return 'border-green-500 bg-green-50';
       case 'restricted': return 'border-yellow-500 bg-yellow-50';
@@ -750,7 +750,7 @@ const RegulatoryCompliance = () => {
     }
   };
 
-  const getStatusIcon = (status) => {
+  const getStatusIcon = (status: 'regulated' | 'restricted' | 'banned' | string): JSX.Element => {
     switch (status) {
       case 'regulated': return <CheckCircle className="h-5 w-5 text-green-600" />;
       case 'restricted': return <AlertTriangle className="h-5 w-5 text-yellow-600" />;


### PR DESCRIPTION
Add explicit TypeScript types to `getStatusColor` and `getStatusIcon` to resolve a TS1109 error and improve type safety.

---
<a href="https://cursor.com/background-agent?bcId=bc-087524f6-7560-4a48-acc5-bc9e74c1ba1c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-087524f6-7560-4a48-acc5-bc9e74c1ba1c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

