### PR TITLE
Fix typescript expression expected error

### DIFF
--- a/src/pages/RegulatoryCompliance.tsx
+++ b/src/pages/RegulatoryCompliance.tsx
@@ -1564,7 +1564,6 @@ const RegulatoryCompliance = () => {
           </div>
         </section>
       </div>
-      </div>
     </>
   );
 };


### PR DESCRIPTION
Remove an extra closing `</div>` to fix a JSX parsing error (TS1109) caused by unbalanced tags.

---
<a href="https://cursor.com/background-agent?bcId=bc-ec9aa58c-a5c6-43ec-ae2d-99f20a24f5df">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ec9aa58c-a5c6-43ec-ae2d-99f20a24f5df">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

